### PR TITLE
Add: add docker compose config

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3'
+services:
+  mysql:
+    ## mysql version, you could get more tags at here : https://hub.docker.com/_/mysql?tab=tags
+    image: "mysql:5.7"
+    ## host port is 3306, you could change to 33060 or any other port doesn't conflict MySQL on your OS
+    ports:
+     - "3306:3306"
+    container_name: sharding-sphere-mysql
+    ## launch mysql without password
+    ## you could access the mysql in container by following command :
+    ## docker exec -it sharding-sphere-mysql mysql -uroot
+    environment:
+     - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+    ## if you insist to use password in mysql, remove MYSQL_ALLOW_EMPTY_PASSWORD=yes and uncomment following args
+    #  - MYSQL_ROOT_PASSWORD=root 
+
+  zookeeper:
+    ## get more versions of zookeeper here : https://hub.docker.com/_/zookeeper?tab=tags
+    image: "zookeeper:3.4"
+    ports: 
+     - "2181:2181"
+    container_name: sharding-sphere-zookeeper
+
+  etcd:
+    ## get more versions of etcd here  : https://quay.io/repository/coreos/etcd?tag=latest&tab=tags
+    image: "quay.io/coreos/etcd:v3.3.12"
+    ports: 
+     - "2379:2379"
+     - "2380:2380"
+     - "4001:4001"
+    container_name: sharding-sphere-etcd
+    entrypoint: /usr/local/bin/etcd
+    command:
+     - '--advertise-client-urls=http://0.0.0.0:2379'
+     - '--listen-client-urls=http://0.0.0.0:2379'
+     - '--initial-advertise-peer-urls=http://0.0.0.0:2380'
+     - '--listen-peer-urls=http://0.0.0.0:2380'
+     - '--initial-cluster'
+     - 'default=http://0.0.0.0:2380'
+  


### PR DESCRIPTION
Fixes #95.

Changes proposed in this pull request:
#### before we use docker compose, please install docker first : https://docs.docker.com/compose/install/
#### usage is as following :
- 1. access the docker folder (cd docker)
- 2. launch the environment by docker compose (docker-compose up -d)
- 3. access mysql / etcd / zookeeper as you want
- 4. if there is conflict on port, just modify the mapper port in docker-compose.yml and then launch docker compose again(docker-compose up -d)
- 5. if you want to stop these environment, use command docker-compose stop

to clean the docker container , you could use docker rm `docker ps -a -q` (be careful)
