### PR TITLE
makes docker compose init manual_schema.sql

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,9 @@ services:
     environment:
      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     ## if you insist to use password in mysql, remove MYSQL_ALLOW_EMPTY_PASSWORD=yes and uncomment following args
-    #  - MYSQL_ROOT_PASSWORD=root 
+    #  - MYSQL_ROOT_PASSWORD=root
+    volumes:
+      - ./manual_schema.sql:/docker-entrypoint-initdb.d/manual_schema.sql
 
   zookeeper:
     ## get more versions of zookeeper here : https://hub.docker.com/_/zookeeper?tab=tags


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
- now docker compose will init manual_schema.sql in mysql after mysql container is initialized

##### however , there is a restriction . we have to put manual_schema.sql with docker-compose-yml together, which mean put these two files in the same folder.

I tried , I tried to execute several commands in mysql container to make sql init automatically . however official delete all unnecessary function to make container clear, light weight, I have to execute following command in container to init sql : 
 - execute apt-get update
 - execute apt-get install wget -y
 - wget manual_schema.sql ...
 - startup mysql service, import the manual_schema.sql file.

that will take a lot of time(depends on the host network) to init container .  

mount the sql file to folder /docker-entrypoint-initdb.d/ in container is the official way . mysql container will init all sh and sql files under docker-entrypoint-initdb.d/

I know this will make manual_schema.sql duplicated in incubator-shardingsphere-example, however , this is the best way I figure out.
