### PR TITLE
Docker compose enhance

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ## if you insist to use password in mysql, remove MYSQL_ALLOW_EMPTY_PASSWORD=yes and uncomment following args
     #  - MYSQL_ROOT_PASSWORD=root
     volumes:
-      - ./manual_schema.sql:/docker-entrypoint-initdb.d/manual_schema.sql
+      - ../src/resources/manual_schema.sql:/docker-entrypoint-initdb.d/manual_schema.sql
 
   zookeeper:
     ## get more versions of zookeeper here : https://hub.docker.com/_/zookeeper?tab=tags

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,9 @@ services:
     environment:
      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     ## if you insist to use password in mysql, remove MYSQL_ALLOW_EMPTY_PASSWORD=yes and uncomment following args
-    #  - MYSQL_ROOT_PASSWORD=root 
+    #  - MYSQL_ROOT_PASSWORD=root
+    volumes:
+      - ./manual_schema.sql:/docker-entrypoint-initdb.d/manual_schema.sql
 
   zookeeper:
     ## get more versions of zookeeper here : https://hub.docker.com/_/zookeeper?tab=tags


### PR DESCRIPTION
enhancement of #96

Changes proposed in this pull request:
- mount init sql to docker-entrypoint-initdb.d . 

when official mysql container start up , init all the shell and sql file under docker-entrypoint-initdb.d .

so, this time,  when docker-compose up -d, we will get an initialized MySQL container.