### PR TITLE
Docker enhancement proxy environment

### DIFF
--- a/docker/sharding-jdbc/sharding/docker-compose.yml
+++ b/docker/sharding-jdbc/sharding/docker-compose.yml
@@ -3,17 +3,19 @@ services:
   mysql:
     ## mysql version, you could get more tags at here : https://hub.docker.com/_/mysql?tab=tags
     image: "mysql:5.7"
-    ## host port is 3306, you could change to 33060 or any other port doesn't conflict MySQL on your OS
+    ## default port is 3306, you could change to 33060 or any other port doesn't conflict MySQL on your OS
     ports:
-     - "3306:3306"
+      - "33060:3306"
     container_name: sharding-sphere-mysql
     ## launch mysql without password
     ## you could access the mysql in container by following command :
     ## docker exec -it sharding-sphere-mysql mysql -uroot
     environment:
-     - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     ## if you insist to use password in mysql, remove MYSQL_ALLOW_EMPTY_PASSWORD=yes and uncomment following args
-    #  - MYSQL_ROOT_PASSWORD=root 
+    #  - MYSQL_ROOT_PASSWORD=root
+    volumes:
+      - ../../../src/resources/manual_schema.sql:/docker-entrypoint-initdb.d/manual_schema.sql
 
   zookeeper:
     ## get more versions of zookeeper here : https://hub.docker.com/_/zookeeper?tab=tags

--- a/docker/sharding-jdbc/sharding/docker-compose.yml
+++ b/docker/sharding-jdbc/sharding/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: "mysql:5.7"
     ## default port is 3306, you could change to 33060 or any other port doesn't conflict MySQL on your OS
     ports:
-      - "33060:3306"
+      - "3306:3306"
     container_name: sharding-sphere-mysql
     ## launch mysql without password
     ## you could access the mysql in container by following command :


### PR DESCRIPTION
Fixes Nothing,  just an enhancement

Changes proposed in this pull request:
- add docker compose for proxy sharding situation
- change the position of docker compose file for sharding jdbc 

#### access docker/sharding-proxy/sharding , and then launch command by "docker compose up -d", docker will establish proxy , mysql container, then access proxy by "mysql -uroot -h127.0.0.1 -P13308 -proot"

#### however, there are something we need pay attention as followings :
 - 1. access proxy by 127.0.0.1 not localhost , remember . localhost and 127.0.0.1 are different, I may fix this difference in next PR
 - 2. entrypoint for proxy image is launch start.sh and print out log immediately, if we just launch proxy container, that's fine. however , by compose , we have to let it wait until related mysql container finished it's initialization . so I invoke the "wait-for-it.sh" . default await completion is 20 seconds , which means proxy container will not launch if mysql container CAN NOT FINISH INITIALIZATION in 20 sec. of course , you can change it (-timeout=20).
 - 3. the correct way to shutdown docker-compose is "docker-compose down", stop and delete every single container is a little bit stupid . please modify the corresponding document in README.md