### PR TITLE
修复4.0.0-RC2-SNAPSHOT无法构建的问题；

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,11 @@
                 <artifactId>sharding-transaction-xa-core</artifactId>
                 <version>${project.parent.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.shardingsphere</groupId>
-                <artifactId>sharding-transaction-base-saga</artifactId>
-                <version>${sharding-sphere.spi.impl.version}</version>
-            </dependency>
+            <!--<dependency>-->
+                <!--<groupId>org.apache.shardingsphere</groupId>-->
+                <!--<artifactId>sharding-transaction-base-saga</artifactId>-->
+                <!--<version>${sharding-sphere.spi.impl.version}</version>-->
+            <!--</dependency>-->
             <dependency>
                 <groupId>org.apache.shardingsphere</groupId>
                 <artifactId>sharding-transaction-base-seata-at</artifactId>
@@ -107,33 +107,33 @@
                 <artifactId>sharding-jdbc-orchestration-spring-namespace</artifactId>
                 <version>${sharding-sphere.version}</version>
             </dependency>
+            <!--<dependency>-->
+                <!--<groupId>org.apache.shardingsphere</groupId>-->
+                <!--<artifactId>sharding-transaction-jdbc-spring</artifactId>-->
+                <!--<version>${sharding-sphere.spi.impl.version}</version>-->
+            <!--</dependency>-->
             <dependency>
-                <groupId>io.shardingsphere</groupId>
-                <artifactId>sharding-transaction-jdbc-spring</artifactId>
-                <version>${sharding-sphere.spi.impl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.shardingsphere</groupId>
+                <groupId>org.apache.shardingsphere</groupId>
                 <artifactId>sharding-transaction-proxy-spring</artifactId>
                 <version>${sharding-sphere.spi.impl.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.shardingsphere</groupId>
-                <artifactId>sharding-transaction-jdbc-spring-boot-starter</artifactId>
-                <version>${sharding-sphere.spi.impl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.shardingsphere</groupId>
-                <artifactId>sharding-transaction-proxy-spring-boot-starter</artifactId>
-                <version>${sharding-sphere.spi.impl.version}</version>
-            </dependency>
+            <!--<dependency>-->
+                <!--<groupId>org.apache.shardingsphere</groupId>-->
+                <!--<artifactId>sharding-transaction-jdbc-spring-boot-starter</artifactId>-->
+                <!--<version>${sharding-sphere.spi.impl.version}</version>-->
+            <!--</dependency>-->
+            <!--<dependency>-->
+                <!--<groupId>org.apache.shardingsphere</groupId>-->
+                <!--<artifactId>sharding-transaction-proxy-spring-boot-starter</artifactId>-->
+                <!--<version>${sharding-sphere.spi.impl.version}</version>-->
+            <!--</dependency>-->
             <dependency>
                 <groupId>org.apache.shardingsphere</groupId>
                 <artifactId>sharding-orchestration-reg-zookeeper-curator</artifactId>
                 <version>${sharding-sphere.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.shardingsphere</groupId>
+                <groupId>org.apache.shardingsphere</groupId>
                 <artifactId>sharding-orchestration-reg-etcd</artifactId>
                 <version>${sharding-sphere.spi.impl.version}</version>
             </dependency>

--- a/sharding-jdbc-example/orchestration-example/orchestration-raw-jdbc-example/pom.xml
+++ b/sharding-jdbc-example/orchestration-example/orchestration-raw-jdbc-example/pom.xml
@@ -31,7 +31,7 @@
             <artifactId>sharding-orchestration-reg-zookeeper-curator</artifactId>
         </dependency>
         <!--<dependency>-->
-            <!--<groupId>io.shardingsphere</groupId>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
             <!--<artifactId>sharding-orchestration-reg-etcd</artifactId>-->
         <!--</dependency>-->
     </dependencies>

--- a/sharding-jdbc-example/orchestration-example/orchestration-spring-boot-example/pom.xml
+++ b/sharding-jdbc-example/orchestration-example/orchestration-spring-boot-example/pom.xml
@@ -25,7 +25,7 @@
             <artifactId>sharding-orchestration-reg-zookeeper-curator</artifactId>
         </dependency>
         <!--<dependency>-->
-            <!--<groupId>io.shardingsphere</groupId>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
             <!--<artifactId>sharding-orchestration-reg-etcd</artifactId>-->
         <!--</dependency>-->
         <dependency>

--- a/sharding-jdbc-example/orchestration-example/orchestration-spring-namespace-example/pom.xml
+++ b/sharding-jdbc-example/orchestration-example/orchestration-spring-namespace-example/pom.xml
@@ -34,7 +34,7 @@
             <artifactId>sharding-orchestration-reg-zookeeper-curator</artifactId>
         </dependency>
         <!--<dependency>-->
-            <!--<groupId>io.shardingsphere</groupId>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
             <!--<artifactId>sharding-orchestration-reg-etcd</artifactId>-->
         <!--</dependency>-->
 

--- a/sharding-jdbc-example/other-feature-example/hint-example/pom.xml
+++ b/sharding-jdbc-example/other-feature-example/hint-example/pom.xml
@@ -26,7 +26,7 @@
     </modules>
     <parent>
         <groupId>org.apache.shardingsphere.example</groupId>
-        <artifactId>sharding-jdbc-example</artifactId>
+        <artifactId>other-feature-example</artifactId>
         <version>4.0.0-RC2-SNAPSHOT</version>
     </parent>
     <artifactId>hint-example</artifactId>

--- a/sharding-jdbc-example/transaction-example/transaction-2pc-xa-example/transaction-xa-spring-boot-example/pom.xml
+++ b/sharding-jdbc-example/transaction-example/transaction-2pc-xa-example/transaction-xa-spring-boot-example/pom.xml
@@ -21,10 +21,10 @@
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-transaction-xa-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-jdbc-spring-boot-starter</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-jdbc-spring-boot-starter</artifactId>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-jdbc-spring-boot-starter</artifactId>

--- a/sharding-jdbc-example/transaction-example/transaction-2pc-xa-example/transaction-xa-spring-namespace-example/pom.xml
+++ b/sharding-jdbc-example/transaction-example/transaction-2pc-xa-example/transaction-xa-spring-namespace-example/pom.xml
@@ -26,10 +26,10 @@
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-jdbc-spring-namespace</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-jdbc-spring</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-jdbc-spring</artifactId>-->
+        <!--</dependency>-->
 
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/sharding-jdbc-example/transaction-example/transaction-base-saga-example/transaction-saga-raw-jdbc-example/pom.xml
+++ b/sharding-jdbc-example/transaction-example/transaction-base-saga-example/transaction-saga-raw-jdbc-example/pom.xml
@@ -21,10 +21,10 @@
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-jdbc-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-base-saga</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-base-saga</artifactId>-->
+        <!--</dependency>-->
     </dependencies>
 
 </project>

--- a/sharding-jdbc-example/transaction-example/transaction-base-saga-example/transaction-saga-spring-boot-example/pom.xml
+++ b/sharding-jdbc-example/transaction-example/transaction-base-saga-example/transaction-saga-spring-boot-example/pom.xml
@@ -16,14 +16,14 @@
             <artifactId>repository-jpa</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-base-saga</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-jdbc-spring-boot-starter</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-base-saga</artifactId>-->
+        <!--</dependency>-->
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-jdbc-spring-boot-starter</artifactId>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-jdbc-spring-boot-starter</artifactId>

--- a/sharding-jdbc-example/transaction-example/transaction-base-saga-example/transaction-saga-spring-namespace-example/pom.xml
+++ b/sharding-jdbc-example/transaction-example/transaction-base-saga-example/transaction-saga-spring-namespace-example/pom.xml
@@ -17,18 +17,18 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-base-saga</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-base-saga</artifactId>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-jdbc-spring-namespace</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-jdbc-spring</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-jdbc-spring</artifactId>-->
+        <!--</dependency>-->
 
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/sharding-jdbc-example/transaction-example/transaction-base-seata-example/transaction-base-seata-spring-boot-example/pom.xml
+++ b/sharding-jdbc-example/transaction-example/transaction-base-seata-example/transaction-base-seata-spring-boot-example/pom.xml
@@ -37,10 +37,10 @@
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-transaction-base-seata-at</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-jdbc-spring-boot-starter</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-jdbc-spring-boot-starter</artifactId>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-jdbc-spring-boot-starter</artifactId>

--- a/sharding-jdbc-example/transaction-example/transaction-base-seata-example/transaction-base-seata-spring-namespace-example/pom.xml
+++ b/sharding-jdbc-example/transaction-example/transaction-base-seata-example/transaction-base-seata-spring-namespace-example/pom.xml
@@ -42,10 +42,10 @@
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>sharding-jdbc-spring-namespace</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-jdbc-spring</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-jdbc-spring</artifactId>-->
+        <!--</dependency>-->
         
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/sharding-proxy-example/sharding-proxy-boot-mybatis-example/pom.xml
+++ b/sharding-proxy-example/sharding-proxy-boot-mybatis-example/pom.xml
@@ -17,10 +17,10 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>io.shardingsphere</groupId>
-            <artifactId>sharding-transaction-proxy-spring-boot-starter</artifactId>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.shardingsphere</groupId>-->
+            <!--<artifactId>sharding-transaction-proxy-spring-boot-starter</artifactId>-->
+        <!--</dependency>-->
         
         <dependency>
             <groupId>org.mybatis</groupId>


### PR DESCRIPTION
1. 老的io.shardingsphere的groupId均更改为org.apache.shardingsphere；
2. 移除了几个在4.0.0-RC2-SNAPSHOT不存在的模块依赖；
3. hint-example的parent应该依赖other-feature-example而不是sharding-jdbc-example

Fixes #162.

Changes proposed in this pull request:
-
-
-
